### PR TITLE
Fix/differences with ft vdcemri

### DIFF
--- a/quantification/quantification.py
+++ b/quantification/quantification.py
@@ -1712,10 +1712,14 @@ class quantificationLogic(ScriptedLoadableModuleLogic):
                 volumeColumn.InsertValue(idx, np.nan)
                 distColumn.InsertValue(idx, np.nan)
         
-        # Add the FTV stats at the end of list
+        # Add the FTV and ETV stats at the end of list
         nameColumn.InsertNextValue('FTV (Functional Tumour Volume)')
         volumeColumn.InsertNextValue(np.round(FTVstats[0],3))
         distColumn.InsertNextValue(np.round(100 * FTVstats[1]/ETVstats[1], 2))
+
+        nameColumn.InsertNextValue('ETV (Enhanced Tumour Volume)')
+        volumeColumn.InsertNextValue(np.round(ETVstats[0],3))
+        distColumn.InsertNextValue(np.round(100.0, 2))
 
         # JU - Update table and plot - TODO: I think this should be moved to a different function
         slicer.util.updateTableFromArray(tableNodeDict['TICTable'][0], time_intensity_curve, tableNodeDict['TICTable'][1])


### PR DESCRIPTION
Modify the interval definition for the SER ranges to be consistent with the original SlicerFTVDCEMRI code, i.e. LB < SER ≤ UB (previously it was defined as LB ≤ SER < UB)
Main changes:
- Define the SER_UPPER_THRESHOLD constant to 3.0, which sets the upper limit for the FTV calculation. Anything above SER_UPPER_THRESHOLD is deemed as "non SER", hence is not summed when calculating FTV and ETV
- Added ETV (Total Enhanced Tumour Volume) stats to the SER Table. ETV corresponds to 100% and includes all valid SER pixels (i.e. 0<SER≤SER_UPPER_THRESHOLD). When using the pre-defined SER range, ETV=FTV. But if setting a SER Threshold (via the slider widget), ETV=100% and FTV is the fraction such that SER > SER Threshold
