### PR TITLE
Added PropagateTiming bool Flag to reuse timing among sequences

### DIFF
--- a/quantification/Resources/UI/quantification.ui
+++ b/quantification/Resources/UI/quantification.ui
@@ -116,16 +116,41 @@
          <string>Identify relevant timepoints</string>
         </property>
         <property name="collapsed">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <layout class="QGridLayout" name="identifyTimepointsGridLayout">
-         <item row="0" column="0">
-          <widget class="QLabel" name="labelSelectPreContrast">
+         <item row="2" column="0">
+          <widget class="QLabel" name="labelSelectLatePostContrast">
            <property name="toolTip">
-            <string>Index of pre-contrast image</string>
+            <string>Index of the late post-contrast image (e.g. the last timepoint in the sequence)</string>
            </property>
            <property name="text">
-            <string>Pre-Contrast Index:</string>
+            <string>Late Post-Contrast Index:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="ctkSliderWidget" name="indexSliderEarlyPostContrast">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Select the index corresponding to the Early post-contrast image</string>
+           </property>
+           <property name="decimals">
+            <number>0</number>
+           </property>
+           <property name="pageStep">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="SlicerParameterName" stdset="0">
+            <string>indicesDCE.earlyPostContrast</string>
            </property>
           </widget>
          </item>
@@ -160,65 +185,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="labelTimePreContrast">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="labelSelectEarlyPostContrast">
-           <property name="toolTip">
-            <string>Index of the early post-contrast image (e.g. the one immediately after contrast injection)</string>
-           </property>
-           <property name="text">
-            <string>Early Post-Contrast Index:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="ctkSliderWidget" name="indexSliderEarlyPostContrast">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Select the index corresponding to the Early post-contrast image</string>
-           </property>
-           <property name="decimals">
-            <number>0</number>
-           </property>
-           <property name="pageStep">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="SlicerParameterName" stdset="0">
-            <string>indicesDCE.earlyPostContrast</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QLabel" name="labelTimeEarlyPostContrast">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="labelSelectLatePostContrast">
-           <property name="toolTip">
-            <string>Index of the late post-contrast image (e.g. the last timepoint in the sequence)</string>
-           </property>
-           <property name="text">
-            <string>Late Post-Contrast Index:</string>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="1">
           <widget class="ctkSliderWidget" name="indexSliderLatePostContrast">
            <property name="enabled">
@@ -244,10 +210,54 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="labelSelectEarlyPostContrast">
+           <property name="toolTip">
+            <string>Index of the early post-contrast image (e.g. the one immediately after contrast injection)</string>
+           </property>
+           <property name="text">
+            <string>Early Post-Contrast Index:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="labelTimeEarlyPostContrast">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="labelSelectPreContrast">
+           <property name="toolTip">
+            <string>Index of pre-contrast image</string>
+           </property>
+           <property name="text">
+            <string>Pre-Contrast Index:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="labelTimePreContrast">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
          <item row="2" column="2">
           <widget class="QLabel" name="labelTimeLatePostContrast">
            <property name="text">
             <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="propagateTimingToggle">
+           <property name="text">
+            <string>Propagate Timings to any derived sequence</string>
+           </property>
+           <property name="SlicerParameterName" stdset="0">
+            <string>propagateTiming</string>
            </property>
           </widget>
          </item>
@@ -1420,6 +1430,22 @@
     <hint type="destinationlabel">
      <x>110</x>
      <y>270</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>quantification</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>propagateTimingToggle</receiver>
+   <slot>toggle()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>457</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>159</x>
+     <y>181</y>
     </hint>
    </hints>
   </connection>

--- a/quantification/quantification.py
+++ b/quantification/quantification.py
@@ -133,6 +133,9 @@ class quantificationParameterNode:
     backgroundThreshold: Annotated[float, WithinRange(0.0, 100.0)] = 60.0
     signalEnhancementRatioThreshold: Annotated[float, WithinRange(0.0, 3.25)] = 1.4
 
+    # # JU - Checkbox to propagate the timings for any other sequence that hasn't DICOM metadata (assumes a single patient in the scene)
+    propagateTiming: bool = True
+
     # # JU - Simple Checkbox to control SER analysis:
     displaySERrange: bool = True
 
@@ -781,10 +784,12 @@ class quantificationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 # Get acquisition times from DICOM metadata (output in ms)
                 self.timeFrames = np.array(self._parameterNode.input4DVolume.GetAttribute("MultiVolume.FrameLabels").split(',')).astype(float)
             else:
-                nt = self._parameterNode.input4DVolume.GetNumberOfDataNodes()
+                if ( (self.timeFrames is None) or (not self._parameterNode.propagateTiming) ):
+                    
+                    nt = self._parameterNode.input4DVolume.GetNumberOfDataNodes()
                 
-                # normalise the time axis to nt = 1min = 60x10e3 [ms] to be consistent with the calculations  
-                self.timeFrames = np.linspace(0, nt*60.0*1.0e3, num=nt, endpoint=True)
+                    # normalise the time axis to nt = 1min = 60x10e3 [ms] to be consistent with the calculations  
+                    self.timeFrames = np.linspace(0, nt*60.0*1.0e3, num=nt, endpoint=True)
 
             logging.debug(f'Timeframe Labels: {self.timeFrames} (ms)')
             


### PR DESCRIPTION
Added a Checkbox to use (TRUE) the timings derived from the DICOM metadata across other sequences. This is useful when registering the sequences, as the registration algorithm (Slicer Sequence Registration module) doesn't have timing information (or I haven't found it yet), so if the "Propagate Timing to any derived sequence" box is checked, it'll use the DICOM metadata from the sequence PREVIOUSLY SELECTED in the Input Volume drop-down. That means, if more than one patient is on the scene, it may generate conflicts depending on which one was selected, as the timings assigned may not be the right ones. I recommend continuing following the recommendation to process one patient at a time (or one patient by scene), as there are other issues too with the segmentation masks, associated with processing simultaneously multiple patients